### PR TITLE
CLJ and CLJS subscriptions with nested path *and* reducer work the same

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.roman01la/citrus "3.2.1"
+(defproject org.roman01la/citrus "3.2.2-SNAPSHOT"
   :description "State management library for Rum"
   :url "https://github.com/roman01la/citrus"
   :license {:name "Eclipse Public License"

--- a/src/citrus/resolver.clj
+++ b/src/citrus/resolver.clj
@@ -10,7 +10,7 @@
       (when state
         (swap! state assoc key data))
       (if reducer
-        (-> data reducer (get-in path))
+        (reducer (get-in data path))
         (get-in data path))))
 
   clojure.lang.IRef

--- a/test/citrus/core_test.clj
+++ b/test/citrus/core_test.clj
@@ -29,4 +29,16 @@
 (deftest subscription
   (testing "Should return Resolver instance"
     (is (instance? citrus.resolver.Resolver
-                   (citrus/subscription (citrus/reconciler {}) [:path])))))
+                   (citrus/subscription (citrus/reconciler {}) [:path]))))
+  (testing "Should return nested data when a nested path is supplied"
+    (let [sub (citrus/subscription (citrus/reconciler {:state (atom {})
+                                                       :resolvers {:a (constantly {:b [1 2 3]})}}) [:a :b])]
+      (is (= @sub [1 2 3]))))
+  (testing "Should return derived data when a reducer function is supplied"
+    (let [sub (citrus/subscription (citrus/reconciler {:state (atom {})
+                                                       :resolvers {:a (constantly {:b [1 2 3]})}}) [:a] map?)]
+      (is (= @sub true))))
+  (testing "Should return derived data when a reducer function *and* nested data are supplied"
+    (let [sub (citrus/subscription (citrus/reconciler {:state (atom {})
+                                                       :resolvers {:a (constantly {:b [1 2 3]})}}) [:a :b] count)]
+      (is (= @sub 3)))))

--- a/test/citrus/resolver_test.clj
+++ b/test/citrus/resolver_test.clj
@@ -17,6 +17,9 @@
   (testing "Should apply reducer to resolved data when dereferenced"
     (let [r (resolver/make-resolver (atom {}) {:path (constantly 1)} [:path] inc)]
       (is (= @r 2))))
+  (testing "Should apply reducer to nested resolved data when dereferenced"
+    (let [r (resolver/make-resolver (atom {}) {:path (constantly {:value 1})} [:path :value] inc)]
+      (is (= @r 2))))
   (testing "Should populate state with resolved data after dereferencing"
     (let [state (atom {})]
       @(resolver/make-resolver state {:path (constantly 1)} [:path] nil)
@@ -24,4 +27,8 @@
   (testing "Should populate state with resolved data after dereferencing given nested path"
     (let [state (atom {})]
       @(resolver/make-resolver state {:path (constantly {:value 1})} [:path :value] nil)
+      (is (= @state {:path {:value 1}}))))
+  (testing "Should populate state with resolved data after dereferencing given nested path and a reducer function"
+    (let [state (atom {})]
+      @(resolver/make-resolver state {:path (constantly {:value 1})} [:path :value] inc)
       (is (= @state {:path {:value 1}})))))


### PR DESCRIPTION
Added some more tests to ensure nothing broke.