### PR TITLE
Don't evaluate default-batched-updates until necessary

### DIFF
--- a/src/citrus/core.cljs
+++ b/src/citrus/core.cljs
@@ -3,7 +3,8 @@
   (:require [citrus.reconciler :as r]
             [citrus.cursor :as c]))
 
-(def ^:private -default-batched-updates
+(defn- -get-default-batched-updates
+  []
   {:schedule-fn js/requestAnimationFrame
    :release-fn  js/cancelAnimationFrame})
 
@@ -28,8 +29,7 @@
 
   Returned value supports deref, watches and metadata.
   The only supported option is `:meta`"
-  [{:keys [state controllers effect-handlers co-effects batched-updates chunked-updates]
-    :or   {batched-updates -default-batched-updates}}
+  [{:keys [state controllers effect-handlers co-effects batched-updates chunked-updates]}
    & {:as options}]
   (binding []
     (let [watch-fns (volatile! {})
@@ -40,7 +40,7 @@
                 state
                 (volatile! [])
                 (volatile! nil)
-                batched-updates
+                (or batched-updates (-get-default-batched-updates))
                 chunked-updates
                 (:meta options)
                 watch-fns)]


### PR DESCRIPTION
The current code uses a `def`, meaning that the map will _always_ be evaluated at run time _even_ if you provide your own functions.

`js/requestAnimationFrame` and `js/cancelAnimationFrame` only exist in the browser, so this fails if you run the code with Node:

```
/home/baptiste/.boot/cache/tmp/home/baptiste/myorg/myapp/8mr/-ueasqk/cljs_test/generated_test_suite.out/citrus/core.js:6
citrus.core._default_batched_updates = new cljs.core.PersistentArrayMap(null, 2, [new cljs.core.Keyword(null,"schedule-fn","schedule-fn",1204822075),requestAnimationFrame,new cljs.core.Keyword(null,"release-fn","release-fn",-1727471084),cancelAnimationFrame], null);
                                                                                                                                                     ^

ReferenceError: requestAnimationFrame is not defined
```
I used an `or` in order to only evaluate `(-get-default-batched-updates)` if `batched-updates` is not defined. This allows one to provide custom batched-updates to run code on Node.

Note `let`’s `:or` doesn’t work because it *always* evaluates its default argument:

```clojure
(let [{:keys [a]
       :or {a (println "hey")}} {:a 42}]
  a)
; "hey"
; => 42
```