### PR TITLE
Add circleci enablement for citrus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+# Clojure CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-clojure/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/clojure:lein-2.9.1
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      LEIN_ROOT: "true"
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "project.clj" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: lein deps
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "project.clj" }}
+
+      # run tests!
+- run: lein test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Clojars Project](https://img.shields.io/clojars/v/clj-commons/citrus.svg)](https://clojars.org/clj-commons/citrus)
 [![cljdoc badge](https://cljdoc.org/badge/clj-commons/citrus)](https://cljdoc.org/d/clj-commons/citrus/CURRENT)
+[![CircleCI](https://circleci.com/gh/clj-commons/citrus.svg?style=svg)](https://circleci.com/gh/clj-commons/citrus)
 
 
 <img src="logo.png" width="252" height="35" alt="citrus logo" />


### PR DESCRIPTION
I think perhaps we could activate circleci before merging to see if it is red? I don't have the rights for that feel free to activate :dog: 