### PR TITLE
Introduce default-handler option

### DIFF
--- a/doc/default-handler.md
+++ b/doc/default-handler.md
@@ -15,8 +15,9 @@ When constructing a reconciler the `:default-handler` option can be used to
 pass a default handler.
 
 - `:default-handler` should be a function like 
-
-	(fn handler [reconciler ctrl-key event-key event-args])
+  ```clj
+  (fn handler [reconciler ctrl-key event-key event-args])
+  ```
 
 - When not passing in anything for this option, the handler will default to
   `citrus.reconciler/citrus-default-handler`, which behaves identical to the

--- a/doc/default-handler.md
+++ b/doc/default-handler.md
@@ -6,7 +6,7 @@ by [the need to access all controllers state in event
 handlers](https://github.com/clj-commons/citrus/issues/50) but theoretically
 they open up Citrus' event handling to many more customizations. 
 
-:warn: Default handlers are experimental and subject to change. Please
+:warning: Default handlers are experimental and subject to change. Please
 report your experiences using them [in this GitHub issue]().
 
 ### Usage 

--- a/doc/default-handler.md
+++ b/doc/default-handler.md
@@ -1,0 +1,57 @@
+# Default Handlers
+
+Default handlers are a way to adapt Citrus' event handling to users needs that
+haven't been anticipated by the framework. Initially they have been motivated
+by [the need to access all controllers state in event
+handlers](https://github.com/clj-commons/citrus/issues/50) but theoretically
+they open up Citrus' event handling to many more customizations. 
+
+:warn: Default handlers are experimental and subject to change. Please
+report your experiences using them [in this GitHub issue]().
+
+### Usage 
+
+When constructing a reconciler the `:default-handler` option can be used to 
+pass a default handler.
+
+- `:default-handler` should be a function like 
+
+	(fn handler [reconciler ctrl-key event-key event-args])
+
+- When not passing in anything for this option, the handler will default to
+  `citrus.reconciler/citrus-default-handler`, which behaves identical to the
+  regular event handling of Citrus as of `v3.2.3`.
+- The handler function is expected to return a new value for the `:state` atom
+  of the reconciler.
+
+### Recipes
+
+#### Passing the entire state as fifth argument
+
+Event handlers currently take four arguments `[controller-kw event-kw
+event-args co-effects]`. As described above one motivation for default handlers
+has been to give event handlers access to the entire state of the application.
+
+By implementing a new default handler based on [`citrus.reconciler/citrus-default-handler`]() we can change how our controller multimethods are called, passing an additional argument containing the applications full state.
+
+> Co-effects are largely undocumented right now and might be removed in a
+> future release. Please [add a note to this
+> issue](https://github.com/clj-commons/citrus/issues/51) if you are using
+> them.
+
+#### Non-multimethod based handlers
+
+TBD 
+
+- include mixture w/ controller based handlers
+- note how non-controller handlers won't work with broadcast
+
+### Appendix
+
+#### Why return `state` from default handler instead of calling `reset!` within handler?
+
+Citrus processes events that are dispatched asynchronously in batches. As
+Citrus processes one batch of events the new app state is computed and then
+`reset!` into the state atom.  If handlers would call `reset!` themselves this
+could in theory cause multiple recomputations of subscriptions. More
+investigation would be useful to diagnose if this is an actual issue.

--- a/doc/default-handler.md
+++ b/doc/default-handler.md
@@ -7,14 +7,14 @@ handlers](https://github.com/clj-commons/citrus/issues/50) but theoretically
 they open up Citrus' event handling to many more customizations. 
 
 :warning: Default handlers are experimental and subject to change. Please
-report your experiences using them [in this GitHub issue]().
+report your experiences using them [in this GitHub issue](https://github.com/clj-commons/citrus/issues/50).
 
 ### Usage 
 
-When constructing a reconciler the `:default-handler` option can be used to 
+When constructing a reconciler the `:default-handler` option can be used to
 pass a default handler.
 
-- `:default-handler` should be a function like 
+- `:default-handler` should be a function like
   ```clj
   (fn handler [reconciler events])
   ;; where `events` is a list of event tuples like this one
@@ -30,29 +30,37 @@ pass a default handler.
   for subscriptions and similar tools using `add-watch` with the reconciler
   `state` atom.
 
-### Writing your own handler
+#### Open extension
+
+With the ability to override the `default-handler` the `controller` and
+`effect-handlers` options almost become superfluous as all behavior influenced
+by these options can now also be controlled via `default-handler`. Some ideas
+for things that are now possible to build on top of Citrus that previously
+weren't:
+
+- Mix controller handlers with custom event handling logic, e.g. any function. This could mean:
+  - Having handlers that use [interceptors](https://github.com/metosin/sieppari) to customize their behavior
+  - Having handlers that can write to the full app state instead of a subtree (as with controllers)
+- Completely replace Citrus multimethod dispatching with a custom handler registry
+
+> **Note** that breaking out of controllers as Citrus provides them impacts how
+> Citrus' `broadcast` functions work.
 
 ### Recipes
 
-#### Passing the entire state as fifth argument
+:wave: Have you used `default-handler` to do something interesting? Open a PR and share your approach here!
+
+#### Passing the entire state as fourth argument
 
 Event handlers currently take four arguments `[controller-kw event-kw
 event-args co-effects]`. As described above one motivation for default handlers
 has been to give event handlers access to the entire state of the application.
 
-By implementing a new default handler based on [`citrus.reconciler/citrus-default-handler`]() we can change how our controller multimethods are called, passing an additional argument containing the applications full state.
+By implementing a new default handler based on [`citrus.reconciler/citrus-default-handler`]() we can change how our controller multimethods are called, replacing the `co-effects` argument with the full state of the reconciler.
 
 > Co-effects are largely undocumented right now and might be removed in a
 > future release. Please [add a note to this
 > issue](https://github.com/clj-commons/citrus/issues/51) if you are using
 > them.
 
-```diff
-```
-
-#### Non-multimethod based handlers
-
-With the ability to override the `default-handler` the `controller` and `effect-handlers` options almost become superfluous as all behavior influenced by these options can now also be controlled via `default-handler`. 
-
-- include mixture w/ controller based handlers
-- note how non-controller handlers won't work with broadcast
+:point_right: Here's [**a commit**](https://github.com/clj-commons/citrus/commit/a620e8e77a62b16a9d6006600cccd02dda82c046) that adapts Citrus' default handler to pass the reconciler's full state as the fourth argument.

--- a/src/citrus/core.cljs
+++ b/src/citrus/core.cljs
@@ -22,7 +22,7 @@
     config              - a map of
       state             - app state atom
       controllers       - a hash of state controllers
-      default-handler   - a function to handle incoming events (see docs)
+      default-handler   - a function to handle incoming events (see doc/default-handler.md)
       effect-handlers   - a hash of effects handlers
       batched-updates   - a hash of two functions used to batch reconciler updates, defaults to
                           `{:schedule-fn js/requestAnimationFrame :release-fn js/cancelAnimationFrame}`

--- a/src/citrus/core.cljs
+++ b/src/citrus/core.cljs
@@ -22,6 +22,7 @@
     config              - a map of
       state             - app state atom
       controllers       - a hash of state controllers
+      default-handler   - a function to handle incoming events (see docs)
       effect-handlers   - a hash of effects handlers
       batched-updates   - a hash of two functions used to batch reconciler updates, defaults to
                           `{:schedule-fn js/requestAnimationFrame :release-fn js/cancelAnimationFrame}`
@@ -29,12 +30,13 @@
 
   Returned value supports deref, watches and metadata.
   The only supported option is `:meta`"
-  [{:keys [state controllers effect-handlers co-effects batched-updates chunked-updates]}
+  [{:keys [state controllers default-handler effect-handlers co-effects batched-updates chunked-updates]}
    & {:as options}]
   (binding []
     (let [watch-fns (volatile! {})
           rec (r/->Reconciler
                 controllers
+                (or default-handler r/citrus-default-handler)
                 effect-handlers
                 co-effects
                 state

--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -84,7 +84,7 @@
 
   IReconciler
   (dispatch! [this cname event args]
-    (assert (some? event) (str "dispatch! was called without event name:" (pr-str cname event args)))
+    (assert (some? event) (str "dispatch! was called without event name:" (pr-str [cname event args])))
     (queue-effects! queue [cname event args])
     (schedule-update!
       batched-updates
@@ -101,9 +101,9 @@
                       st)))))))
 
   (dispatch-sync! [this cname event args]
-    (assert (some? event) (str "dispatch! was called without event name:" (pr-str cname event args)))
     (when-let [new-state (default-handler this cname event args)]
       (reset! state new-state)))
+    (assert (some? event) (str "dispatch! was called without event name:" (pr-str [cname event args])))
 
   (broadcast! [this event args]
     (m/doseq [controller (keys controllers)]

--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -52,7 +52,7 @@
                     (handler reconciler ctrl effect))))
               (if (contains? effects :state)
                 (recur (assoc state ctrl (:state effects)) events)
-                (recur state events))))))) ))
+                (recur state events)))))))))
 
 (defprotocol IReconciler
   (dispatch! [this controller event args])

--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -1,7 +1,6 @@
 (ns citrus.reconciler
   (:require-macros [citrus.macros :as m])
-  (:require [cljs.spec.alpha :as s]
-            [goog.object :as gobj]))
+  (:require [cljs.spec.alpha :as s]))
 
 (defn- queue-effects! [queue f]
   (vswap! queue conj f))
@@ -24,10 +23,10 @@
 
      [ctrl event-key event-args]"
   [reconciler events]
-  (let [controllers (gobj/get reconciler "controllers")
-        co-effects (gobj/get reconciler "co_effects")
-        effect-handlers (gobj/get reconciler "effect_handlers")
-        state-atom (gobj/get reconciler "state")]
+  (let [controllers (.-controllers reconciler)
+        co-effects (.-co_effects reconciler)
+        effect-handlers (.-effect_handlers reconciler)
+        state-atom (.-state reconciler)]
     (reset!
       state-atom
       (loop [state @reconciler

--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -101,9 +101,8 @@
                       st)))))))
 
   (dispatch-sync! [this cname event args]
-    (when-let [new-state (default-handler this cname event args)]
-      (reset! state new-state)))
     (assert (some? event) (str "dispatch! was called without event name:" (pr-str [cname event args])))
+    (reset! (default-handler this cname event args) new-state))
 
   (broadcast! [this event args]
     (m/doseq [controller (keys controllers)]

--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -90,8 +90,8 @@
       batched-updates
       scheduled?
       (fn []
-        (let [events @queue
-              _ (clear-queue! queue)]
+        (let [events @queue]
+          (clear-queue! queue)
           (reset! state
                   (loop [st @state
                          [event & events] events]

--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -102,7 +102,7 @@
 
   (dispatch-sync! [this cname event args]
     (assert (some? event) (str "dispatch! was called without event name:" (pr-str [cname event args])))
-    (reset! (default-handler this cname event args) new-state))
+    (reset! state (default-handler this cname event args)))
 
   (broadcast! [this event args]
     (m/doseq [controller (keys controllers)]

--- a/test/citrus/custom_handler_test.cljs
+++ b/test/citrus/custom_handler_test.cljs
@@ -1,0 +1,80 @@
+(ns citrus.custom-handler-test
+  (:require [clojure.test :refer [deftest testing is async]]
+            [citrus.core :as citrus]
+            [citrus.reconciler :as rec]
+            [citrus.cursor :as cur]
+            [goog.object :as gobj]
+            [rum.core :as rum]))
+
+(defn mk-citrus-map-dispatch-handler
+  "An example of a different default "
+  [handlers]
+  (fn [reconciler events]
+    (let [state-atom (gobj/get reconciler "state")]
+      ;; (add-watch state-atom :logger
+      ;;            (fn [_key _atom old-state new-state]
+      ;;              (js/console.log (pr-str "old:" old-state))
+      ;;              (js/console.log (pr-str "new:" new-state))))
+      (reset!
+        state-atom
+        (loop [state @reconciler
+               [[ctrl event-key event-args :as event] & events] events]
+          (if (nil? event)
+            state
+            (if-let [handler (get handlers (keyword ctrl event-key))]
+              (recur (handler state event-args) events)
+              (let [e (ex-info (str "No handler for " (keyword ctrl event-key)) {})]
+                (js/console.error e)
+                (throw e))))) ))))
+
+(def handlers
+  {:user/log-in (fn [state [user-name]]
+                  (assoc state :current-user user-name))
+   :user/log-out (fn [state _]
+                   (dissoc state :current-user))
+   :counters/reset (fn [state [counter-key]]
+                     (assoc-in state [:counters counter-key] 0))
+   :counters/inc (fn [state [counter-key]]
+                   (update-in state [:counters counter-key] (fnil inc 0)))
+   :counters/dec (fn [state [counter-key]]
+                   (update-in state [:counters counter-key] (fnil dec 0)))})
+
+(def r (citrus/reconciler {:state           (atom {})
+                           :default-handler (mk-citrus-map-dispatch-handler handlers)}))
+
+(def current-user (citrus/subscription r [:current-user]))
+(def counters (citrus/subscription r [:counters]))
+
+(deftest initial-state
+  (testing "Checking initial state in atom"
+    (is (nil? @current-user))
+    (is (nil? @counters))))
+
+(deftest dispatch-sync-test
+  (testing "One dispatch-sync! works"
+    (citrus/dispatch-sync! r :counters :inc :a)
+    (is (= {:a 1} @counters)))
+
+  (testing "dispatch-sync! in a series keeps the the last call"
+    (dotimes [_ 10]
+      (citrus/dispatch-sync! r :counters :inc :x))
+    (is (= {:a 1 :x 10} @counters)))
+
+  (testing "dispatch-sync! a non-existing event fails"
+    (is (thrown-with-msg? js/Error
+                          #"No handler for :test/non-existing-event"
+                          (citrus/dispatch-sync! r :test :non-existing-event)))))
+
+(deftest dispatch-test
+  (testing "dispatch! in a series preservers order"
+    (dotimes [_ 10]
+      (citrus/dispatch! r :counters :inc :a))
+    (citrus/dispatch! r :counters :reset :a)
+    (dotimes [_ 5]
+      (citrus/dispatch! r :counters :inc :a))
+    (citrus/dispatch! r :user :log-in "roman")
+    (async done (js/requestAnimationFrame
+                  (fn []
+                    (is (= {:a 5 :x 10} @counters))
+                    (is (= "roman" @current-user))
+                    (done))))) )

--- a/test/citrus/test_runner.cljs
+++ b/test/citrus/test_runner.cljs
@@ -1,5 +1,6 @@
 (ns citrus.test-runner
   (:require [doo.runner :refer-macros [doo-tests]]
-            [citrus.core-test]))
+            [citrus.core-test]
+            [citrus.custom-handler-test]))
 
-(doo-tests 'citrus.core-test)
+(doo-tests 'citrus.core-test 'citrus.custom-handler-test)


### PR DESCRIPTION
Fixes #50 

Documentation still work in progress but tests are passing and code is ready. 

Feedback appreciated, please read the accompanying documentation file and issue #50 for additional context.

Some interesting observations:

1. Ignoring `broadcast` the default handler option could remove the need for controllers to be a property of the `Reconciler` instance. Instead the default handler could be constructed with a map of controllers as an input.
2. Similar things apply to `effects` and `co-effects`.