### PR TITLE
run cljs tests in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/clojure:lein-2.9.1-browsers
+      - image: circleci/clojure:lein-2.9.1-node-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/clojure:lein-2.9.1
+      - image: circleci/clojure:lein-2.9.1-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -40,3 +40,7 @@ jobs:
 
       # run tests!
       - run: lein test
+
+      # run cljs tests!
+      - run: npm ci
+      - run: lein doo chrome test once

--- a/src/citrus/reconciler.cljs
+++ b/src/citrus/reconciler.cljs
@@ -92,7 +92,7 @@
                         (when-let [handler (get effect-handlers id)]
                           (handler this cname effect))))
                     (if (contains? effects :state)
-                      (recur (:state effects) events)
+                      (recur (assoc st cname (:state effects)) events)
                       (recur st events)))
                   st))]
           (reset! state next-state)))))
@@ -108,7 +108,7 @@
                    (assoc cofx key (apply (co-effects key) args)))
                  {}
                  cofx)
-          effects (ctrl event args @state cofx)]
+          effects (ctrl event args (get @state cname) cofx)]
       (m/doseq [effect effects]
         (let [[id effect] effect
               handler (get effect-handlers id)]
@@ -116,7 +116,7 @@
             (when-let [spec (s/get-spec id)]
               (s/assert spec effect)))
           (cond
-            (= id :state) (reset! state effect)
+            (= id :state) (swap! state assoc cname effect)
             handler (handler this cname effect)
             :else nil)))))
 

--- a/test/citrus/core_test.clj
+++ b/test/citrus/core_test.clj
@@ -1,5 +1,5 @@
 (ns citrus.core-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
             [citrus.core :as citrus]))
 
 (deftest reconciler

--- a/test/citrus/core_test.cljs
+++ b/test/citrus/core_test.cljs
@@ -11,7 +11,7 @@
     (let [r (citrus/reconciler {:state (atom {}) :controllers {}})]
       (is (instance? rec/Reconciler r)))))
 
-(deftest subscription
+(deftest subscription-resolver-instance
   (testing "Should return a Resolver instance"
     (let [r (citrus/reconciler {:state (atom {}) :controllers {}})]
       (is (instance? cur/ReduceCursor


### PR DESCRIPTION
Tests pass with 8f04be93 but are broken by the "pass whole state into event handlers" commit (61210a3) so I reverted that one as part of this PR.